### PR TITLE
Integrate Geist UI into frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Makers URL Shortener
+
+This repository provides a minimal Cloudflare Workers backend for generating short URLs.
+
+## API Usage
+
+Send a **POST** request to the Worker with JSON body:
+
+```json
+{
+  "url": "https://example.com"
+}
+```
+
+Successful requests return:
+
+```json
+{
+  "status": 200,
+  "key": "/xxxxx"
+}
+```
+
+Prefix the returned `key` with the Worker domain to create the full short link. For example, if your Worker is deployed at `https://url.example.workers.dev` and the `key` returned is `/demo`, the short link is:
+
+```
+https://url.example.workers.dev/demo
+```
+
+## Deployment
+
+1. Create a KV namespace called `LINKS` and bind it to your Worker through the Cloudflare dashboard or CLI.
+2. Copy the code from `src/index.js` into your Worker's script and deploy it.
+
+## Frontend
+
+This repository also includes a small Next.js frontend in the `frontend`
+directory built with [Geist UI](https://geist-ui.dev). Set the environment
+variable `NEXT_PUBLIC_WORKER_URL` to the URL of your deployed Worker, then run
+the development server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Open `http://localhost:3000` in your browser to access the page and generate
+short links.
+
+## License
+
+This project is released under the AGPLv3 License. See `LICENSE.md` for details.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.next

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "url-shortener-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@geist-ui/react": "^2.2.4"
+  }
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import {
+  GeistProvider,
+  CssBaseline,
+  Input,
+  Button,
+  Text,
+  Link,
+} from '@geist-ui/react';
+
+export default function Home() {
+  const [url, setUrl] = useState('');
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState(null);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setResult(null);
+    setError(null);
+
+    const workerUrl = process.env.NEXT_PUBLIC_WORKER_URL;
+    if (!workerUrl) {
+      setError('NEXT_PUBLIC_WORKER_URL not set');
+      return;
+    }
+
+    try {
+      const res = await fetch(workerUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url })
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setResult(`${workerUrl.replace(/\/$/, '')}${data.key}`);
+      } else {
+        setError(data.error || 'Request failed');
+      }
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <GeistProvider>
+      <CssBaseline />
+      <main style={{ padding: '2rem' }}>
+        <Text h1>URL Shortener</Text>
+        <form onSubmit={submit}>
+          <Input
+            width="300px"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://example.com"
+            required
+          />
+          <Button type="success" htmlType="submit" style={{ marginTop: '1rem' }}>
+            Shorten
+          </Button>
+        </form>
+        {result && (
+          <Text>
+            Short link: <Link href={result}>{result}</Link>
+          </Text>
+        )}
+        {error && <Text type="error">{error}</Text>}
+      </main>
+    </GeistProvider>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,64 @@
+// Minimal Cloudflare Worker for generating and resolving short URLs.
+// Bind a KV namespace named "LINKS" to persist mappings.
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (request.method === 'POST' && url.pathname === '/') {
+      return await handlePost(request, env.LINKS);
+    }
+
+    if (request.method === 'GET') {
+      const key = url.pathname.slice(1);
+      if (key) {
+        const target = await env.LINKS.get(key);
+        if (target) {
+          return Response.redirect(target, 302);
+        }
+      }
+      return new Response('Not found', { status: 404 });
+    }
+
+    return new Response('Method not allowed', { status: 405 });
+  }
+};
+
+async function handlePost(request, LINKS) {
+  let data;
+  try {
+    data = await request.json();
+  } catch {
+    return new Response(JSON.stringify({ status: 400, error: 'Invalid JSON' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' }
+    });
+  }
+
+  const url = data && data.url;
+  if (typeof url !== 'string' || (!url.startsWith('http://') && !url.startsWith('https://'))) {
+    return new Response(JSON.stringify({ status: 400, error: 'Invalid url' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' }
+    });
+  }
+
+  const key = await generateKey(LINKS);
+  await LINKS.put(key, url);
+  return new Response(JSON.stringify({ status: 200, key: `/${key}` }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' }
+  });
+}
+
+async function generateKey(LINKS, length = 6) {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  while (true) {
+    const arr = new Uint8Array(length);
+    crypto.getRandomValues(arr);
+    const key = Array.from(arr).map(i => chars[i % chars.length]).join('');
+    const exists = await LINKS.get(key);
+    if (!exists) {
+      return key;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- use Geist UI components on the Next.js page
- add `@geist-ui/react` dependency
- note in README that the frontend uses Geist UI

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ff1236918832bb4492f669a31bf76