### PR TITLE
Add CORS headers to worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Prefix the returned `key` with the Worker domain to create the full short link. 
 https://url.example.workers.dev/demo
 ```
 
+### CORS
+
+The Worker responds with permissive CORS headers, allowing requests from any origin.
+`OPTIONS` preflight requests return a `204` status so browsers can call the API
+without additional configuration.
+
 ## Deployment
 
 1. Create a KV namespace called `LINKS` and bind it to your Worker through the Cloudflare dashboard or CLI.

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,21 @@
 // Minimal Cloudflare Worker for generating and resolving short URLs.
 // Bind a KV namespace named "LINKS" to persist mappings.
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
 
+    if (request.method === 'OPTIONS') {
+      return withCors(new Response(null, { status: 204 }));
+    }
+
     if (request.method === 'POST' && url.pathname === '/') {
-      return await handlePost(request, env.LINKS);
+      return withCors(await handlePost(request, env.LINKS));
     }
 
     if (request.method === 'GET') {
@@ -13,15 +23,20 @@ export default {
       if (key) {
         const target = await env.LINKS.get(key);
         if (target) {
-          return Response.redirect(target, 302);
+          return withCors(Response.redirect(target, 302));
         }
       }
-      return new Response('Not found', { status: 404 });
+      return withCors(new Response('Not found', { status: 404 }));
     }
 
-    return new Response('Method not allowed', { status: 405 });
+    return withCors(new Response('Method not allowed', { status: 405 }));
   }
 };
+
+function withCors(response) {
+  Object.entries(corsHeaders).forEach(([k, v]) => response.headers.set(k, v));
+  return response;
+}
 
 async function handlePost(request, LINKS) {
   let data;


### PR DESCRIPTION
## Summary
- add permissive CORS headers in `src/index.js`
- document CORS behavior in README

## Testing
- `node --check src/index.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ffb788eb8832b9776ead767681cba